### PR TITLE
feat: open files in the editor

### DIFF
--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorFileIO.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorFileIO.java
@@ -1,0 +1,39 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// (C) Copyright 2018-2026 Modeling Value Group B.V. (http://modelingvalue.org)                                        ~
+//                                                                                                                     ~
+// Licensed under the GNU Lesser General Public License v3.0 (the 'License'). You may not use this file except in      ~
+// compliance with the License. You may obtain a copy of the License at: https://choosealicense.com/licenses/lgpl-3.0  ~
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on ~
+// an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the  ~
+// specific language governing permissions and limitations under the License.                                          ~
+//                                                                                                                     ~
+// Maintainers:                                                                                                        ~
+//     Wim Bast, Tom Brus                                                                                              ~
+//                                                                                                                     ~
+// Contributors:                                                                                                       ~
+//     Victor Lap                                                                                                      ~
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+package org.modelingvalue.nelumbo.tools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * UTF-8 text read/write for file-backed editor windows. Pure filesystem IO with
+ * no Swing dependency so it can be unit-tested in isolation.
+ */
+public final class EditorFileIO {
+    private EditorFileIO() {
+    }
+
+    public static String read(Path path) throws IOException {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    public static void write(Path path, String text) throws IOException {
+        Files.writeString(path, text, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -68,6 +68,7 @@ public class EditorWindow extends WindowAdapter
     private volatile boolean    isExample;
     private final String        examplePath;
     private final String        exampleDisplayName;
+    private final String        filePath;          // Absolute filesystem path for file-backed windows (null otherwise)
     private final Preferences   preferences;
     private volatile int        windowNumber;      // Window number for regular windows
 
@@ -107,6 +108,7 @@ public class EditorWindow extends WindowAdapter
         this.exampleDisplayName = null;
         this.windowNumber = windowNumber;
         this.preferences = Preferences.userNodeForPackage(NelumboEditor.class);
+        this.filePath = null;
     }
 
     /**
@@ -121,6 +123,23 @@ public class EditorWindow extends WindowAdapter
         this.exampleDisplayName = exampleDisplayName;
         this.windowNumber = -1; // Examples don't have window numbers
         this.preferences = Preferences.userNodeForPackage(NelumboEditor.class);
+        this.filePath = null;
+    }
+
+    /**
+     * Creates a new editable window backed by a filesystem file. Reuses the
+     * regular-window machinery (numbered, importable); the file path drives load,
+     * debounced auto-save, and the window title.
+     */
+    public EditorWindow(NelumboEditor application, String windowId, int windowNumber, String filePath) {
+        this.application = application;
+        this.windowId = windowId != null ? windowId : UUID.randomUUID().toString();
+        this.isExample = false;
+        this.examplePath = null;
+        this.exampleDisplayName = null;
+        this.windowNumber = windowNumber;
+        this.preferences = Preferences.userNodeForPackage(NelumboEditor.class);
+        this.filePath = filePath;
     }
 
     public String getWindowId() {
@@ -183,6 +202,9 @@ public class EditorWindow extends WindowAdapter
         if (isExample && exampleDisplayName != null) {
             // Example/library windows use just the display name
             title = exampleDisplayName;
+        } else if (filePath != null) {
+            // File-backed windows show the file's base name
+            title = new java.io.File(filePath).getName();
         } else {
             // Regular windows use "editor.nelumbo_<n>" format for easy import reference
             title = "editor.nelumbo_" + windowNumber;

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -83,6 +83,8 @@ public class EditorWindow extends WindowAdapter
     private UndoManager                      undoManager;
     private CompoundEdit                     currentCompoundEdit;
     private Timer                            compoundEditTimer;
+    private Timer                            fileSaveTimer;
+    private volatile String                  pendingFileSaveText;
     private WindowManager.WindowListListener windowListListener;
     private volatile boolean                 quit;
     private boolean                          refreshRequested;
@@ -304,6 +306,12 @@ public class EditorWindow extends WindowAdapter
         // Timer to end compound edits after a pause in typing (500ms)
         compoundEditTimer = new Timer(500, e -> endCompoundEdit());
         compoundEditTimer.setRepeats(false);
+
+        // Timer to debounce writing the file after a pause in typing (500ms).
+        // Only file-backed windows schedule it (see saveTextContent), but it is
+        // harmless to create for every window.
+        fileSaveTimer = new Timer(500, e -> flushFileSave());
+        fileSaveTimer.setRepeats(false);
 
         textPane.getDocument().addUndoableEditListener(e -> {
             // Only capture INSERT and REMOVE events, not CHANGE (style) events
@@ -1359,7 +1367,15 @@ public class EditorWindow extends WindowAdapter
         try {
             // Save example info (always needed for window restoration)
             preferences.putBoolean(prefKey("isExample"), isExample);
-            if (isExample) {
+            if (filePath != null) {
+                // File-backed window: the file on disk is the source of truth.
+                // Persist only the path (for restore) and debounce the disk write.
+                preferences.put(prefKey("filePath"), filePath);
+                if (windowNumber > 0) {
+                    preferences.putInt(prefKey("windowNumber"), windowNumber);
+                }
+                scheduleFileSave(text);
+            } else if (isExample) {
                 // For example windows, only save the example path, not the content
                 // The content will be reloaded from the resource file on restore
                 if (examplePath != null) {
@@ -1392,6 +1408,29 @@ public class EditorWindow extends WindowAdapter
         } catch (Exception e) {
             System.err.println("Failed to save window content: " + e.getMessage());
         }
+    }
+
+    private void scheduleFileSave(String text) {
+        pendingFileSaveText = text;
+        fileSaveTimer.restart();
+    }
+
+    private void flushFileSave() {
+        String text = pendingFileSaveText;
+        if (text == null || filePath == null) {
+            return;
+        }
+        // Write off the EDT so disk IO never stalls the UI. The text was captured
+        // on the EDT in scheduleFileSave.
+        new Thread(() -> {
+            try {
+                EditorFileIO.write(Path.of(filePath), text);
+            } catch (IOException ex) {
+                // Fail loud: a swallowed auto-save loses edits. Surface in the messages pane.
+                javax.swing.SwingUtilities.invokeLater(() -> setMessages(
+                        "Failed to save " + new File(filePath).getName() + ": " + ex.getMessage()));
+            }
+        }, "EditorFileSave-" + windowId).start();
     }
 
     private void loadTextContent() {

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -823,10 +823,16 @@ public class EditorWindow extends WindowAdapter
     }
 
     private void openFileChooser() {
-        JFileChooser chooser = new JFileChooser();
-        chooser.setFileFilter(new javax.swing.filechooser.FileNameExtensionFilter("Nelumbo files (*.nl)", "nl"));
-        if (chooser.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
-            application.getWindowManager().createFileWindow(chooser.getSelectedFile());
+        // Use the AWT FileDialog so the OS-native open panel is shown (Cocoa on macOS).
+        FileDialog dialog = new FileDialog(frame, "Open", FileDialog.LOAD);
+        dialog.setFilenameFilter((dir, name) -> name.endsWith(".nl")); // honored on macOS
+        if (!System.getProperty("os.name").toLowerCase().contains("mac")) {
+            dialog.setFile("*.nl"); // Windows/Linux filter via a glob in the file field
+        }
+        dialog.setVisible(true);
+        String name = dialog.getFile();
+        if (name != null) {
+            application.getWindowManager().createFileWindow(new File(dialog.getDirectory(), name));
         }
     }
 
@@ -981,6 +987,7 @@ public class EditorWindow extends WindowAdapter
     private void closeWindow() {
         if (confirmCloseIfEditable()) {
             saveTextContent(getDocumentText(textPane));
+            flushFileSaveNow();
             saveDialogVisibility();
             frame.setVisible(false);
             frame.dispose();
@@ -992,6 +999,9 @@ public class EditorWindow extends WindowAdapter
      * the window should be closed, false to cancel.
      */
     private boolean confirmCloseIfEditable() {
+        if (filePath != null) {
+            return true; // File-backed windows auto-save to disk; closing loses nothing.
+        }
         if (textPane.isEditable()) {
             int result = JOptionPane.showConfirmDialog(frame,
                     "The contents of this window will be lost. Are you sure you want to close it?", "Close Window",
@@ -1059,6 +1069,7 @@ public class EditorWindow extends WindowAdapter
         if (confirmCloseIfEditable()) {
             // Save state before closing (content is only saved for non-example windows)
             saveTextContent(getDocumentText(textPane));
+            flushFileSaveNow();
             saveDialogVisibility();
             frame.setVisible(false);
             frame.dispose();
@@ -1475,6 +1486,28 @@ public class EditorWindow extends WindowAdapter
                         "Failed to save " + new File(filePath).getName() + ": " + ex.getMessage()));
             }
         }, "EditorFileSave-" + windowId).start();
+    }
+
+    /**
+     * Writes any pending debounced file content immediately and synchronously.
+     * Called on close so edits made within the last debounce window are not lost.
+     */
+    private void flushFileSaveNow() {
+        if (filePath == null) {
+            return;
+        }
+        fileSaveTimer.stop(); // cancel the pending async write; we write synchronously here
+        String text = pendingFileSaveText;
+        if (text == null) {
+            return;
+        }
+        try {
+            EditorFileIO.write(Path.of(filePath), text);
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(frame,
+                    "Failed to save " + new File(filePath).getName() + ": " + ex.getMessage(), "Error",
+                    JOptionPane.ERROR_MESSAGE);
+        }
     }
 
     private void loadTextContent() {

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -986,12 +986,21 @@ public class EditorWindow extends WindowAdapter
 
     private void closeWindow() {
         if (confirmCloseIfEditable()) {
-            saveTextContent(getDocumentText(textPane));
-            flushFileSaveNow();
-            saveDialogVisibility();
+            saveAndFlush();
             frame.setVisible(false);
             frame.dispose();
         }
+    }
+
+    /**
+     * Persists this window's content and flushes any pending file write. Shared by
+     * the close-window and application-quit paths so neither loses unsaved edits.
+     */
+    void saveAndFlush() {
+        // Content is only persisted for non-example windows; file windows write to disk.
+        saveTextContent(getDocumentText(textPane));
+        flushFileSaveNow();
+        saveDialogVisibility();
     }
 
     /**
@@ -1066,14 +1075,7 @@ public class EditorWindow extends WindowAdapter
 
     @Override
     public synchronized void windowClosing(WindowEvent evt) {
-        if (confirmCloseIfEditable()) {
-            // Save state before closing (content is only saved for non-example windows)
-            saveTextContent(getDocumentText(textPane));
-            flushFileSaveNow();
-            saveDialogVisibility();
-            frame.setVisible(false);
-            frame.dispose();
-        }
+        closeWindow();
     }
 
     @Override

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -38,6 +38,7 @@ import java.awt.event.*;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
@@ -1457,7 +1458,7 @@ public class EditorWindow extends WindowAdapter
 
     private void loadFileContent() {
         try {
-            String         content = EditorFileIO.read(java.nio.file.Path.of(filePath));
+            String         content = EditorFileIO.read(Path.of(filePath));
             StyledDocument doc     = textPane.getStyledDocument();
             doc.insertString(0, content, null);
 

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -177,6 +177,8 @@ public class EditorWindow extends WindowAdapter
         initActions();
         if (isExample && examplePath != null) {
             loadExampleContent();
+        } else if (filePath != null) {
+            loadFileContent();
         } else {
             loadTextContent();
         }
@@ -1449,6 +1451,24 @@ public class EditorWindow extends WindowAdapter
             doc.setParagraphAttributes(0, doc.getLength(), paragraphStyle, false);
         } catch (IOException e) {
             JOptionPane.showMessageDialog(frame, "Error loading example: " + e.getMessage(), "Error",
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void loadFileContent() {
+        try {
+            String         content = EditorFileIO.read(java.nio.file.Path.of(filePath));
+            StyledDocument doc     = textPane.getStyledDocument();
+            doc.insertString(0, content, null);
+
+            // Apply line spacing
+            SimpleAttributeSet paragraphStyle = new SimpleAttributeSet();
+            StyleConstants.setLineSpacing(paragraphStyle, 0.2f);
+            doc.setParagraphAttributes(0, doc.getLength(), paragraphStyle, false);
+
+            textPane.setCaretPosition(0);
+        } catch (IOException | BadLocationException e) {
+            JOptionPane.showMessageDialog(frame, "Error loading file: " + e.getMessage(), "Error",
                     JOptionPane.ERROR_MESSAGE);
         }
     }

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -300,6 +300,37 @@ public class EditorWindow extends WindowAdapter
         frame.addWindowListener(this);
         textPane.getDocument().addDocumentListener(this);
 
+        // Accept dropped files (open each in a new window) while delegating all
+        // other transfers (text paste/drag) to the pane's original handler.
+        final TransferHandler originalTransferHandler = textPane.getTransferHandler();
+        textPane.setTransferHandler(new TransferHandler() {
+            @Override
+            public boolean canImport(TransferSupport support) {
+                if (support.isDataFlavorSupported(java.awt.datatransfer.DataFlavor.javaFileListFlavor)) {
+                    return true;
+                }
+                return originalTransferHandler != null && originalTransferHandler.canImport(support);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public boolean importData(TransferSupport support) {
+                if (support.isDataFlavorSupported(java.awt.datatransfer.DataFlavor.javaFileListFlavor)) {
+                    try {
+                        java.util.List<java.io.File> files = (java.util.List<java.io.File>) support.getTransferable()
+                                .getTransferData(java.awt.datatransfer.DataFlavor.javaFileListFlavor);
+                        for (java.io.File file : files) {
+                            application.getWindowManager().createFileWindow(file);
+                        }
+                        return true;
+                    } catch (Exception ex) {
+                        return false;
+                    }
+                }
+                return originalTransferHandler != null && originalTransferHandler.importData(support);
+            }
+        });
+
         // Setup undo manager with compound edit grouping
         undoManager = new UndoManager();
 

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -702,6 +702,11 @@ public class EditorWindow extends WindowAdapter
         newWindowItem.addActionListener(e -> application.createNewWindow());
         fileMenu.add(newWindowItem);
 
+        JMenuItem openItem = new JMenuItem("Open…");
+        openItem.setAccelerator(KeyStroke.getKeyStroke('O', Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+        openItem.addActionListener(e -> openFileChooser());
+        fileMenu.add(openItem);
+
         JMenuItem closeWindowItem = new JMenuItem("Close Window");
         closeWindowItem
                 .setAccelerator(KeyStroke.getKeyStroke('W', Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
@@ -784,6 +789,14 @@ public class EditorWindow extends WindowAdapter
         application.getWindowManager().addWindowListListener(windowListListener);
 
         return menuBar;
+    }
+
+    private void openFileChooser() {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileFilter(new javax.swing.filechooser.FileNameExtensionFilter("Nelumbo files (*.nl)", "nl"));
+        if (chooser.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
+            application.getWindowManager().createFileWindow(chooser.getSelectedFile());
+        }
     }
 
     /**

--- a/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/EditorWindow.java
@@ -1008,16 +1008,22 @@ public class EditorWindow extends WindowAdapter
      * the window should be closed, false to cancel.
      */
     private boolean confirmCloseIfEditable() {
-        if (filePath != null) {
-            return true; // File-backed windows auto-save to disk; closing loses nothing.
+        if (!needsCloseConfirmation()) {
+            return true; // File windows auto-save; read-only windows have nothing to lose.
         }
-        if (textPane.isEditable()) {
-            int result = JOptionPane.showConfirmDialog(frame,
-                    "The contents of this window will be lost. Are you sure you want to close it?", "Close Window",
-                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-            return result == JOptionPane.YES_OPTION;
-        }
-        return true; // Read-only windows can be closed without confirmation
+        int result = JOptionPane.showConfirmDialog(frame,
+                "The contents of this window will be lost. Are you sure you want to close it?", "Close Window",
+                JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+        return result == JOptionPane.YES_OPTION;
+    }
+
+    /**
+     * Whether closing this window would discard content the user might want to
+     * keep: an editable, non-file window. File-backed windows auto-save to disk
+     * and read-only windows have nothing to lose, so neither needs confirmation.
+     */
+    boolean needsCloseConfirmation() {
+        return filePath == null && textPane.isEditable();
     }
 
     /**

--- a/src/main/java/org/modelingvalue/nelumbo/tools/NelumboEditor.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/NelumboEditor.java
@@ -164,6 +164,7 @@ public class NelumboEditor {
         initLookAndFeel();
         loadTokenColors();
         windowManager = new WindowManager(this);
+        installQuitHandler();
 
         // Create and register the editor import resolver
         editorImportResolver = new EditorImportResolver(windowManager);
@@ -198,6 +199,24 @@ public class NelumboEditor {
      */
     public void createNewWindow() {
         windowManager.createNewWindow();
+    }
+
+    /**
+     * On macOS the native screen menu bar handles Cmd-Q itself, bypassing the
+     * File &gt; Quit menu action. Route that native quit through {@link #quit()} so
+     * the confirmation prompt and file flush still run.
+     */
+    private void installQuitHandler() {
+        if (!Desktop.isDesktopSupported()) {
+            return;
+        }
+        Desktop desktop = Desktop.getDesktop();
+        if (desktop.isSupported(Desktop.Action.APP_QUIT_HANDLER)) {
+            desktop.setQuitHandler((e, response) -> {
+                quit();                // proceeds to System.exit when confirmed
+                response.cancelQuit(); // only reached when the user cancelled
+            });
+        }
     }
 
     /**

--- a/src/main/java/org/modelingvalue/nelumbo/tools/NelumboEditor.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/NelumboEditor.java
@@ -204,7 +204,7 @@ public class NelumboEditor {
     /**
      * On macOS the native screen menu bar handles Cmd-Q itself, bypassing the
      * File &gt; Quit menu action. Route that native quit through {@link #quit()} so
-     * the confirmation prompt and file flush still run.
+     * the per-window file flush still runs before the app exits.
      */
     private void installQuitHandler() {
         if (!Desktop.isDesktopSupported()) {
@@ -212,28 +212,16 @@ public class NelumboEditor {
         }
         Desktop desktop = Desktop.getDesktop();
         if (desktop.isSupported(Desktop.Action.APP_QUIT_HANDLER)) {
-            desktop.setQuitHandler((e, response) -> {
-                quit();                // proceeds to System.exit when confirmed
-                response.cancelQuit(); // only reached when the user cancelled
-            });
+            desktop.setQuitHandler((e, response) -> quit()); // quit() saves, flushes, and exits
         }
     }
 
     /**
-     * Quits the application, saving all windows first. If any open windows would
-     * lose content, asks for a single confirmation before quitting.
+     * Quits the application, saving and flushing all windows first. Quitting
+     * preserves every window (regular windows restore from preferences, file
+     * windows from disk), so it needs no confirmation.
      */
     public void quit() {
-        int unsaved = windowManager.unsavedWindowCount();
-        if (unsaved > 0) {
-            int result = JOptionPane.showConfirmDialog(null,
-                    "The contents of " + unsaved + " window" + (unsaved == 1 ? "" : "s")
-                            + " will be lost. Are you sure you want to quit?",
-                    "Quit", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-            if (result != JOptionPane.YES_OPTION) {
-                return;
-            }
-        }
         windowManager.saveAllWindows();
         System.exit(0);
     }

--- a/src/main/java/org/modelingvalue/nelumbo/tools/NelumboEditor.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/NelumboEditor.java
@@ -201,9 +201,20 @@ public class NelumboEditor {
     }
 
     /**
-     * Quits the application, saving all windows first.
+     * Quits the application, saving all windows first. If any open windows would
+     * lose content, asks for a single confirmation before quitting.
      */
     public void quit() {
+        int unsaved = windowManager.unsavedWindowCount();
+        if (unsaved > 0) {
+            int result = JOptionPane.showConfirmDialog(null,
+                    "The contents of " + unsaved + " window" + (unsaved == 1 ? "" : "s")
+                            + " will be lost. Are you sure you want to quit?",
+                    "Quit", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+            if (result != JOptionPane.YES_OPTION) {
+                return;
+            }
+        }
         windowManager.saveAllWindows();
         System.exit(0);
     }

--- a/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
@@ -197,10 +197,13 @@ public class WindowManager {
     }
 
     /**
-     * Saves all windows' state (called on quit).
+     * Saves all windows' state and flushes pending file writes (called on quit),
+     * using the same per-window persistence as closing a window.
      */
     public void saveAllWindows() {
-        // Windows save their own state on close, but we save the window list here
+        for (EditorWindow window : getWindowsInOrder()) {
+            window.saveAndFlush();
+        }
         saveWindowList();
     }
 

--- a/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
@@ -16,6 +16,7 @@
 
 package org.modelingvalue.nelumbo.tools;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -147,6 +148,21 @@ public class WindowManager {
     }
 
     /**
+     * Creates a new editable window backed by a filesystem file.
+     */
+    public synchronized void createFileWindow(File file) {
+        String       windowId     = UUID.randomUUID().toString();
+        int          windowNumber = getNextWindowNumber();
+        EditorWindow window       = new EditorWindow(application, windowId, windowNumber, file.getAbsolutePath());
+        windowNumbers.put(windowId, windowNumber);
+        windowOrder.add(windowId);
+        windows.put(windowId, window);
+        saveWindowList();
+        startWindowInNewThread(window);
+        notifyWindowListChanged();
+    }
+
+    /**
      * Starts the given window in a new thread.
      */
     private void startWindowInNewThread(EditorWindow window) {
@@ -225,10 +241,16 @@ public class WindowManager {
             String  examplePath        = preferences.get("window." + windowId + ".examplePath", null);
             String  exampleDisplayName = preferences.get("window." + windowId + ".exampleDisplayName", null);
             int     savedWindowNumber  = preferences.getInt("window." + windowId + ".windowNumber", -1);
+            String  filePath           = preferences.get("window." + windowId + ".filePath", null);
 
             EditorWindow window;
             if (isExample && examplePath != null) {
                 window = new EditorWindow(application, windowId, true, examplePath, exampleDisplayName);
+            } else if (filePath != null) {
+                // File-backed window: reload from disk
+                int windowNumber = savedWindowNumber > 0 ? savedWindowNumber : getNextWindowNumber();
+                windowNumbers.put(windowId, windowNumber);
+                window = new EditorWindow(application, windowId, windowNumber, filePath);
             } else {
                 // For regular windows, use saved number or get a new one
                 int windowNumber = savedWindowNumber > 0 ? savedWindowNumber : getNextWindowNumber();

--- a/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
@@ -208,20 +208,6 @@ public class WindowManager {
     }
 
     /**
-     * Number of open windows whose content would be lost on close (editable,
-     * non-file windows). Used to decide whether quitting needs confirmation.
-     */
-    public int unsavedWindowCount() {
-        int count = 0;
-        for (EditorWindow window : getWindowsInOrder()) {
-            if (window.needsCloseConfirmation()) {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    /**
      * Returns a list of all windows in order.
      */
     public List<EditorWindow> getWindowsInOrder() {

--- a/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
+++ b/src/main/java/org/modelingvalue/nelumbo/tools/WindowManager.java
@@ -208,6 +208,20 @@ public class WindowManager {
     }
 
     /**
+     * Number of open windows whose content would be lost on close (editable,
+     * non-file windows). Used to decide whether quitting needs confirmation.
+     */
+    public int unsavedWindowCount() {
+        int count = 0;
+        for (EditorWindow window : getWindowsInOrder()) {
+            if (window.needsCloseConfirmation()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
      * Returns a list of all windows in order.
      */
     public List<EditorWindow> getWindowsInOrder() {

--- a/src/test/java/org/modelingvalue/nelumbo/test/EditorFileIOTest.java
+++ b/src/test/java/org/modelingvalue/nelumbo/test/EditorFileIOTest.java
@@ -1,0 +1,63 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// (C) Copyright 2018-2026 Modeling Value Group B.V. (http://modelingvalue.org)                                        ~
+//                                                                                                                     ~
+// Licensed under the GNU Lesser General Public License v3.0 (the 'License'). You may not use this file except in      ~
+// compliance with the License. You may obtain a copy of the License at: https://choosealicense.com/licenses/lgpl-3.0  ~
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on ~
+// an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the  ~
+// specific language governing permissions and limitations under the License.                                          ~
+//                                                                                                                     ~
+// Maintainers:                                                                                                        ~
+//     Wim Bast, Tom Brus                                                                                              ~
+//                                                                                                                     ~
+// Contributors:                                                                                                       ~
+//     Victor Lap                                                                                                      ~
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+package org.modelingvalue.nelumbo.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.modelingvalue.nelumbo.tools.EditorFileIO;
+
+public class EditorFileIOTest {
+
+    @Test
+    void writeThenReadRoundTrips(@TempDir Path dir) throws IOException {
+        Path   file    = dir.resolve("sample.nl");
+        String content = "Person :: Object\npc(Hendrik, Juliana)\n";
+        EditorFileIO.write(file, content);
+        assertEquals(content, EditorFileIO.read(file));
+    }
+
+    @Test
+    void writeOverwritesExistingContent(@TempDir Path dir) throws IOException {
+        // Auto-save writes the whole file each time; the second write must fully replace the first.
+        Path file = dir.resolve("sample.nl");
+        EditorFileIO.write(file, "first version");
+        EditorFileIO.write(file, "second");
+        assertEquals("second", EditorFileIO.read(file));
+    }
+
+    @Test
+    void roundTripsUtf8(@TempDir Path dir) throws IOException {
+        // Nelumbo source uses non-ASCII operators (e.g. ∀, ⇔); they must survive a save/load cycle.
+        Path   file    = dir.resolve("unicode.nl");
+        String content = "café — π ∀x";
+        EditorFileIO.write(file, content);
+        assertEquals(content, EditorFileIO.read(file));
+    }
+
+    @Test
+    void readMissingFileThrows(@TempDir Path dir) {
+        // Opening a path that does not exist must fail loudly so the window can show an error.
+        Path missing = dir.resolve("does-not-exist.nl");
+        assertThrows(IOException.class, () -> EditorFileIO.read(missing));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the ability to open filesystem files in the Nelumbo editor and auto-save edits back to disk.

- **Open a file** via **File → Open…** (⌘O, native OS file dialog with a `.nl` filter) or by **drag-and-dropping** files onto the editor. Each opens in a new window titled with the file's base name.
- **Debounced auto-save**: edits to a file-backed window are written to disk ~500ms after typing stops (off the EDT). On restart, file windows reload from disk.
- A new `EditorFileIO` helper isolates UTF-8 read/write (unit-tested); window load/save branch on an optional `filePath`.
- **Unified teardown**: close-window, window-X, and quit all route through `EditorWindow.saveAndFlush()`, so a pending file write is flushed synchronously on close/quit (no last-keystrokes data loss). The macOS native ⌘Q is routed through `quit()` via a `Desktop` quit handler so it flushes too.
- **Close vs quit semantics**: closing one window clears its preferences (it won't restore) and keeps the existing confirmation prompt; quitting preserves and restores every window, so it exits silently with no misleading "contents will be lost" prompt.

Internal note: `getEditorFileName()` still returns `editor.nelumbo_<n>.nl` for file windows by design, so cross-window import/go-to-definition keep working by number; only the display title shows the base name.

## Test plan

- [x] `./gradlew test` — full core + LSP suite green, including new `EditorFileIOTest` (UTF-8 round-trip, overwrite, missing-file error).
- [x] `./gradlew build` and `./gradlew editorJar` succeed.
- [ ] Manual (macOS GUI): File → Open… shows the native dialog with `.nl` filter; chosen file opens with base-name title.
- [ ] Manual: drag-drop a `.nl` file (and multiple files) onto the editor opens them.
- [ ] Manual: edit a file window, pause ~1s, confirm the change is on disk; rapid edits coalesce into one write.
- [ ] Manual: quit (⌘Q and File → Quit) and relaunch — file windows reload from disk, regular windows restore from preferences; no false data-loss prompt.
- [ ] Manual: closing a single editable window still prompts and does not restore.
- [ ] Manual: ordinary text copy/paste/drag inside the editor still works (delegating TransferHandler).
- [ ] Manual: write-failure (e.g. read-only file) surfaces an error rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)